### PR TITLE
Handle group names that are too long

### DIFF
--- a/posthdf.ado
+++ b/posthdf.ado
@@ -27,7 +27,8 @@ all available groups will be posted.
 
 > __3.__ Any character invalid for being used in Stata names, such as '/',
 will be replaced by '_' automatically when the data are loaded.
-A group name should not be longer than 27 characters.
+
+> __4.__ A group name should not be longer than 27 characters.
 Otherwise, it will be truncated.
 
 | _options_ | Default | Description |
@@ -130,8 +131,9 @@ through {help estimates:{bf:estimates store}}.
 Any character contained in a group name that is invalid for
 being used in a Stata name
 will be replaced by an underscore character '_' automatically.
-If a group name contains more than 27 characters,
-it will be truncated to satisfy the maximum length for {help estimates:{bf:estimates store}}.
+A group name that is longer than 27 characters
+will be truncated to satisfy
+the maximum length allowed by {help estimates:{bf:estimates store}}.
 
 An HDF5 _dataset_ holds the data as an array.
 Each object such as the coefficient vector,

--- a/posthdf.ado
+++ b/posthdf.ado
@@ -25,8 +25,10 @@ is required unless {help usehdf:{bf:usehdf}} has been called.
 > __2.__ If neither _groupnames_ nor option __i(_#_)__ is specified,
 all available groups will be posted.
 
-> __3.__ The '/' contained in group names is not allowed in Stata names.
-Hence, any '/' will be replaced by '_' automatically when the data are loaded.
+> __3.__ Any character invalid for being used in Stata names, such as '/',
+will be replaced by '_' automatically when the data are loaded.
+A group name should not be longer than 27 characters.
+Otherwise, it will be truncated.
 
 | _options_ | Default | Description |
 |:----------------|:------------|:-------------------------------------------------|
@@ -125,8 +127,11 @@ will be posted in the same collection in Stata
 as if they were generated from an e-class command.
 The group name will also be used to save the results
 through {help estimates:{bf:estimates store}}.
-A group name that is invalid for being used as a Stata name
-will be converted automatically.
+Any character contained in a group name that is invalid for
+being used in a Stata name
+will be replaced by an underscore character '_' automatically.
+If a group name contains more than 27 characters,
+it will be truncated to satisfy the maximum length for {help estimates:{bf:estimates store}}.
 
 An HDF5 _dataset_ holds the data as an array.
 Each object such as the coefficient vector,

--- a/posthdf.py
+++ b/posthdf.py
@@ -92,14 +92,21 @@ def load(path, rootname, root, groups, append):
         if len(gs) == 0:
             h.visititems(get_parents)
             gs = [g if g == '/' else g[1:] for g in set(load.parents)]
-        if root=='noroot':
+        if root == 'noroot':
             gs = [g for g in gs if g != '/']
         if len(gs) == 0:
             SFIToolkit.errprintln('No group is found.')
             SFIToolkit.exit(7103)
         for g in gs:
             # Stata name does not allow '/'
-            e = sn(rootname) if g == '/' else sn(g)
+            e = sn(rootname) if g == '/' else g
+            # Ensure group name is not too long for est store
+            if len(e)>27:
+                SFIToolkit.errprintln('Warning: The following group name is too long for Stata:')
+                SFIToolkit.errprintln(e)
+                SFIToolkit.errprintln('Try truncating the name to 27 characters.')
+                e = e[:27]
+            e = sn(g)
             if g in h:
                 d = {}
                 for k, v in h[g].items():

--- a/posthdf.py
+++ b/posthdf.py
@@ -103,8 +103,8 @@ def load(path, rootname, root, groups, append):
             # Ensure group name is not too long for est store
             if len(e)>27:
                 SFIToolkit.errprintln('Warning: The following group name is too long for Stata:')
-                SFIToolkit.errprintln(e)
-                SFIToolkit.errprintln('Try truncating the name to 27 characters.')
+                SFIToolkit.errprintln('  '+e)
+                SFIToolkit.errprintln('  Try truncating the name to 27 characters.')
                 e = e[:27]
             e = sn(g)
             if g in h:

--- a/posthdf.py
+++ b/posthdf.py
@@ -99,14 +99,15 @@ def load(path, rootname, root, groups, append):
             SFIToolkit.exit(7103)
         for g in gs:
             # Stata name does not allow '/'
-            e = sn(rootname) if g == '/' else g
+            e = rootname if g == '/' else g
             # Ensure group name is not too long for est store
             if len(e)>27:
                 SFIToolkit.errprintln('Warning: The following group name is too long for Stata:')
                 SFIToolkit.errprintln('  '+e)
                 SFIToolkit.errprintln('  Try truncating the name to 27 characters.')
                 e = e[:27]
-            e = sn(g)
+            # Replace any invalid character with '_'
+            e = sn(e)
             if g in h:
                 d = {}
                 for k, v in h[g].items():

--- a/posthdf.sthlp
+++ b/posthdf.sthlp
@@ -27,8 +27,11 @@ is required unless {help usehdf:{bf:usehdf}} has been called.
 {p 8 8 2} {bf:2.} If neither {it:groupnames} nor option {bf:i({it:#})} is specified,
 all available groups will be posted.
 
-{p 8 8 2} {bf:3.} The {c 39}/{c 39} contained in group names is not allowed in Stata names.
-Hence, any {c 39}/{c 39} will be replaced by {c 39}_{c 39} automatically when the data are loaded.
+{p 8 8 2} {bf:3.} Any character invalid for being used in Stata names, such as {c 39}/{c 39},
+will be replaced by {c 39}_{c 39} automatically when the data are loaded.
+
+{p 8 8 2} {bf:4.} A group name should not be longer than 27 characters.
+Otherwise, it will be truncated.
 
 {col 5}{it:options}{col 22}Default{col 35}Description
 {space 4}{hline}
@@ -139,8 +142,12 @@ will be posted in the same collection in Stata
 as if they were generated from an e-class command.
 The group name will also be used to save the results
 through {help estimates:{bf:estimates store}}.
-A group name that is invalid for being used as a Stata name
-will be converted automatically.
+Any character contained in a group name that is invalid for
+being used in a Stata name
+will be replaced by an underscore character {c 39}_{c 39} automatically.
+A group name that is longer than 27 characters
+will be truncated to satisfy
+the maximum length allowed by {help estimates:{bf:estimates store}}.
 
 {p 4 4 2}
 An HDF5 {it:dataset} holds the data as an array.

--- a/usehdf.ado
+++ b/usehdf.ado
@@ -86,7 +86,11 @@ Hence, if a group name has to contain '/'
 (which is the case whenever the group is below the root group by two or more levels),
 any '/' is replaced by '_'.
 
-> __2.__ The loaded data are stored in Python dictionaries.
+> __2.__ A group name that is longer than 27 characters
+will be truncated to satisfy
+the maximum length allowed by {help estimates:{bf:estimates store}}.
+
+> __3.__ The loaded data are stored in Python dictionaries.
 To access these data in Python,
 enter {help python:Python} interactive environment and import __ests__:
 

--- a/usehdf.sthlp
+++ b/usehdf.sthlp
@@ -97,7 +97,11 @@ Hence, if a group name has to contain {c 39}/{c 39}
 (which is the case whenever the group is below the root group by two or more levels),
 any {c 39}/{c 39} is replaced by {c 39}_{c 39}.
 
-{p 8 8 2} {bf:2.} The loaded data are stored in Python dictionaries.
+{p 8 8 2} {bf:2.} A group name that is longer than 27 characters
+will be truncated to satisfy
+the maximum length allowed by {help estimates:{bf:estimates store}}.
+
+{p 8 8 2} {bf:3.} The loaded data are stored in Python dictionaries.
 To access these data in Python,
 enter {help python:Python} interactive environment and import {bf:ests}:
 


### PR DESCRIPTION
`SFIToolkit.strToName` truncates names to 32 characters. `estimates store` in Stata will add a prefix `_est_` internally. Hence, the maximum length allowed for group names should be 27 characters.

When a group name is too long, print a warning before truncating the name to 27 characters.