### PR TITLE
Select groups to be posted based on keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ they can be converted into a format that Stata understands
 using a parser specified by option `parser`.
 Users can provide their own parsers if desired.
 
-Please see the help files for details on syntax and more examples.
+Please see the help files for details on available options and more examples.
 
 ## Contributing
 

--- a/posthdf.ado
+++ b/posthdf.ado
@@ -23,7 +23,8 @@ __Notes:__
 is required unless {help usehdf:{bf:usehdf}} has been called.
 
 > __2.__ If neither _groupnames_ nor option __i(_#_)__ is specified,
-all available groups will be posted.
+all available groups will be posted unless __with(_strlist_)__
+or __without(_strlist_)__ is specified.
 
 > __3.__ Any character invalid for being used in Stata names, such as '/',
 will be replaced by '_' automatically when the data are loaded.
@@ -36,6 +37,8 @@ Otherwise, it will be truncated.
 | __**p**arser(_str_)__ | {space 1} | interpret {help fvvarlist:factor variables} and {help tsvarlist:time-series operators} from |
 | {space 1} | {space 1} | coefficient names with the specified method (see {help posthdf##parsers:Parsers}) |
 | {bf:i({help numlist:{it:numlist}})} | {space 1} | post the {bf:i}th group in __e()__ when the order is known from {help usehdf:{bf:usehdf}} |
+| __**w**ith(_strlist_)__ | {space 1} | only post groups with at least one of the strings in the group name |
+| __**witho**ut(_strlist_)__ | {space 1} | do not post groups with any of the strings in the group name |
 | __**nos**tore__ | {space 1} | do not store results through {help estimates:{bf:estimates store}} |
 | __b(_str_)__ | 'b' | specify key for the matrix __b__ |
 | __v(_str_)__ | 'V' | specify key for the matrix __V__ |
@@ -44,8 +47,13 @@ Otherwise, it will be truncated.
 | __**o**bs(_str_)__ | 'N' | specify key for the number of observations |
 | __**d**ofr(_str_)__ | 'df_r' | specify key for the residual degrees of freedom |
 
-__Note:__
-'Key' refers to the name of the HDF5 dataset containing the relevant object.
+__Notes:__
+
+> __1.__ The options __with(_strlist_)__ and __without(_strlist_)__
+have precedence over optional arguments _groupnames_ and option __i(_#_)__
+for selecting the groups.
+
+> __2.__ 'Key' refers to the name of the HDF5 dataset containing the relevant object.
 All the data where specifying the key is allowed
 are related to {help ereturn:{bf:ereturn post}}.
 If the keys are misspecified, the data will still be posted.
@@ -303,7 +311,8 @@ This help file was dynamically produced by
 program posthdf, eclass
     version 16
     syntax [namelist(name=groupnames)] [using/] ///
-        [, i(numlist >0 int) Parser(string) noStore ///
+        [, Parser(string) i(numlist >0 int) ///
+        With(string) WITHOut(string) noStore ///
         b(string) v(string) ///
         y(string) CNames(string) Obs(string) Dofr(string) ///
         Name(string) Root noRoot GRoups(string) Append]
@@ -332,6 +341,7 @@ program posthdf, eclass
     if "`dofr'" == "" {
         local dofr "df_r"
     }
+    python: parse_withs_withouts("`with'", "`without'")
     if "`i'" != "" {
         foreach n of numlist `i' {
             local id = `n' - 1
@@ -351,6 +361,6 @@ end
 
 version 16
 python:
-from posthdf import post, postall
+from posthdf import parse_withs_withouts, post, postall
 from coefname_parsers import iwm
 end

--- a/posthdf.ado
+++ b/posthdf.ado
@@ -22,7 +22,7 @@ __Notes:__
 > __1.__ __using__ _filename_
 is required unless {help usehdf:{bf:usehdf}} has been called.
 
-> __2.__ If neither _groupnames_ nor option __i(_#_)__ is specified,
+> __2.__ If neither _groupnames_ nor option {bf:i({help numlist:{it:numlist}})} is specified,
 all available groups will be posted unless __with(_strlist_)__
 or __without(_strlist_)__ is specified.
 
@@ -50,7 +50,7 @@ Otherwise, it will be truncated.
 __Notes:__
 
 > __1.__ The options __with(_strlist_)__ and __without(_strlist_)__
-have precedence over optional arguments _groupnames_ and option __i(_#_)__
+have precedence over optional arguments _groupnames_ and option {bf:i({help numlist:{it:numlist}})}
 for selecting the groups.
 
 > __2.__ 'Key' refers to the name of the HDF5 dataset containing the relevant object.

--- a/posthdf.ado
+++ b/posthdf.ado
@@ -184,25 +184,21 @@ are loaded into memory;
 while in the previous example, all the data are loaded
 even though the remaining data are not posted in __e()__.
 
-If the coefficient names are stored in a dataset with some name other than 'coefnames',
-it can be specified as follows:
-
-> __. posthdf using example.h5, cnames(key_for_names)__
-
-To select a parser for interpreting the coefficient names:
-
-> __. posthdf using example.h5, parser(iwm)__
-
-More details on the use of parsers can be found in {help posthdf##parsers:Parsers}.
-
-__Note:__
-
-> Whenever any option for keys or the parser is specified,
-as in the above two examples,
-they are applied to all the selected groups.
-
 For the remaining examples,
 assume that data have been loaded by calling {help usehdf:{bf:usehdf}}.
+
+To select the groups based on keywords contained in the group names,
+use the __with()__ option:
+
+> __. posthdf, with(A 4)__
+
+In the above example, if the groups loaded in memory
+have the names __A_2__, __B_2__, __A_4__ and __B_4__,
+the group __B_2__ is not posted.
+
+Alternatively, the option __without()__ can be specified:
+
+> __. posthdf, without(B_2)__
 
 If groups __A__ and __B__ are known to be the first and second groups respectively
 from __r(hdfgroup_names)__ returned by {help usehdf:{bf:usehdf}},
@@ -220,6 +216,23 @@ __r(n_hdfgroup)__ and __r(hdfgroup_names)__ which are returned by {help usehdf##
 > __. foreach g in `r(hdfgroup_names)' {c -(}__  
 {space 2}2. _do something for group `g'_  
 {space 2}3. __{c )-}__
+
+If the coefficient names are stored in a dataset with some name other than 'coefnames',
+it can be specified as follows:
+
+> __. posthdf, cnames(key_for_names)__
+
+To select a parser for interpreting the coefficient names:
+
+> __. posthdf, parser(iwm)__
+
+More details on the use of parsers can be found in {help posthdf##parsers:Parsers}.
+
+__Note:__
+
+> Whenever any option for keys or the parser is specified,
+as in the above two examples,
+they are applied to all the selected groups.
 
 {marker parsers}{...}
 Parsers

--- a/posthdf.py
+++ b/posthdf.py
@@ -150,8 +150,8 @@ def load(path, rootname, root, groups, append):
         SFIToolkit.errprintln('No data found.')
         SFIToolkit.exit(7103)
     elif len(ests) > 300:
-        SFIToolkit.errprintln('Warning: The number of groups in memory has passed 300, which is the maximum number of estimation results allowed by Stata.')
-        SFIToolkit.errprintln('  Results have to be posted in batches.')
+        SFIToolkit.displayln('{text:Warning: The number of groups in memory has passed 300, which is the maximum number of estimation results allowed by Stata.}')
+        SFIToolkit.displayln('{text:  Results have to be posted in batches.}')
     n_est = str(len(ests))
     est_keys = ' '.join(ests.keys())
     f = str(p)

--- a/posthdf.py
+++ b/posthdf.py
@@ -14,6 +14,20 @@ ests = OrderedDict()
 # Container for user-provided parsers
 custom_parsers = []
 
+# Containers for with and without options
+withs = []
+withouts = []
+
+def parse_withs_withouts(s1, s2):
+    """Convert inputs into unique words and check validity
+    """
+    global withs, withouts
+    s1, s2 = set(s1.split()), set(s2.split())
+    if len(s1 & s2) > 0:
+        SFIToolkit.errprintln('The same string cannot be passed to both options with() and without().')
+        SFIToolkit.exit(7103)
+    withs, withouts = list(s1), list(s2)
+
 def get_scalar(x):
     """Handle iterable object read from HDF5 when scalar is expected
     """
@@ -159,8 +173,25 @@ def post(gname, parser, nostore, key_b, key_V, key_y, key_cnames, key_N, key_dof
         else:
             SFIToolkit.errprintln('Specified group name is not in memory.')
             SFIToolkit.exit(7103)
-    else:
-        est = ests[gname]
+    # Check whether gname contains any string in withs
+    if withs != []:
+        has_with = False
+        for s in withs:
+            if s in gname:
+                has_with = True
+                break
+        if not has_with:
+            return
+    # Check whether gname contains any string in withouts
+    if withouts != []:
+        has_without = False
+        for s in withouts:
+            if s in gname:
+                has_without = True
+                break
+        if has_without:
+            return
+    est = ests[gname]
     cnames = None
     if key_cnames in est:
         cnames = list(est[key_cnames])

--- a/posthdf.py
+++ b/posthdf.py
@@ -149,6 +149,9 @@ def load(path, rootname, root, groups, append):
     if len(ests) == 0:
         SFIToolkit.errprintln('No data found.')
         SFIToolkit.exit(7103)
+    elif len(ests) > 300:
+        SFIToolkit.errprintln('Warning: The number of groups in memory has passed 300, which is the maximum number of estimation results allowed by Stata.')
+        SFIToolkit.errprintln('  Results have to be posted in batches.')
     n_est = str(len(ests))
     est_keys = ' '.join(ests.keys())
     f = str(p)

--- a/posthdf.sthlp
+++ b/posthdf.sthlp
@@ -24,8 +24,9 @@ and {it:filename} is the path to the {help posthdf##HDF5:HDF5 file}.
 {p 8 8 2} {bf:1.} {bf:using} {it:filename}
 is required unless {help usehdf:{bf:usehdf}} has been called.
 
-{p 8 8 2} {bf:2.} If neither {it:groupnames} nor option {bf:i({it:#})} is specified,
-all available groups will be posted.
+{p 8 8 2} {bf:2.} If neither {it:groupnames} nor option {bf:i({help numlist:{it:numlist}})} is specified,
+all available groups will be posted unless {bf:with({it:strlist})}
+or {bf:without({it:strlist})} is specified.
 
 {p 8 8 2} {bf:3.} Any character invalid for being used in Stata names, such as {c 39}/{c 39},
 will be replaced by {c 39}_{c 39} automatically when the data are loaded.
@@ -38,6 +39,8 @@ Otherwise, it will be truncated.
 {col 5}{bf:{ul:p}arser({it:str})}{col 22}{space 1}{col 35}interpret {help fvvarlist:factor variables} and {help tsvarlist:time-series operators} from
 {col 5}{space 1}{col 22}{space 1}{col 35}coefficient names with the specified method (see {help posthdf##parsers:Parsers})
 {col 5}{bf:i({help numlist:{it:numlist}})}{col 22}{space 1}{col 35}post the {bf:i}th group in {bf:e()} when the order is known from {help usehdf:{bf:usehdf}}
+{col 5}{bf:{ul:w}ith({it:strlist})}{col 22}{space 1}{col 35}only post groups with at least one of the strings in the group name
+{col 5}{bf:{ul:witho}ut({it:strlist})}{col 22}{space 1}{col 35}do not post groups with any of the strings in the group name
 {col 5}{bf:{ul:nos}tore}{col 22}{space 1}{col 35}do not store results through {help estimates:{bf:estimates store}}
 {col 5}{bf:b({it:str})}{col 22}{c 39}b{c 39}{col 35}specify key for the matrix {bf:b}
 {col 5}{bf:v({it:str})}{col 22}{c 39}V{c 39}{col 35}specify key for the matrix {bf:V}
@@ -47,8 +50,13 @@ Otherwise, it will be truncated.
 {col 5}{bf:{ul:d}ofr({it:str})}{col 22}{c 39}df_r{c 39}{col 35}specify key for the residual degrees of freedom
 {space 4}{hline}
 {p 4 4 2}
-{bf:Note:}
-{c 39}Key{c 39} refers to the name of the HDF5 dataset containing the relevant object.
+{bf:Notes:}
+
+{p 8 8 2} {bf:1.} The options {bf:with({it:strlist})} and {bf:without({it:strlist})}
+have precedence over optional arguments {it:groupnames} and option {bf:i({help numlist:{it:numlist}})}
+for selecting the groups.
+
+{p 8 8 2} {bf:2.} {c 39}Key{c 39} refers to the name of the HDF5 dataset containing the relevant object.
 All the data where specifying the key is allowed
 are related to {help ereturn:{bf:ereturn post}}.
 If the keys are misspecified, the data will still be posted.
@@ -197,29 +205,24 @@ while in the previous example, all the data are loaded
 even though the remaining data are not posted in {bf:e()}.
 
 {p 4 4 2}
-If the coefficient names are stored in a dataset with some name other than {c 39}coefnames{c 39},
-it can be specified as follows:
-
-{p 8 8 2} {bf:. posthdf using example.h5, cnames(key_for_names)}
-
-{p 4 4 2}
-To select a parser for interpreting the coefficient names:
-
-{p 8 8 2} {bf:. posthdf using example.h5, parser(iwm)}
-
-{p 4 4 2}
-More details on the use of parsers can be found in {help posthdf##parsers:Parsers}.
-
-{p 4 4 2}
-{bf:Note:}
-
-{p 8 8 2} Whenever any option for keys or the parser is specified,
-as in the above two examples,
-they are applied to all the selected groups.
-
-{p 4 4 2}
 For the remaining examples,
 assume that data have been loaded by calling {help usehdf:{bf:usehdf}}.
+
+{p 4 4 2}
+To select the groups based on keywords contained in the group names,
+use the {bf:with()} option:
+
+{p 8 8 2} {bf:. posthdf, with(A 4)}
+
+{p 4 4 2}
+In the above example, if the groups loaded in memory
+have the names {bf:A_2}, {bf:B_2}, {bf:A_4} and {bf:B_4},
+the group {bf:B_2} is not posted.
+
+{p 4 4 2}
+Alternatively, the option {bf:without()} can be specified:
+
+{p 8 8 2} {bf:. posthdf, without(B_2)}
 
 {p 4 4 2}
 If groups {bf:A} and {bf:B} are known to be the first and second groups respectively
@@ -239,6 +242,27 @@ Note that to loop through all the groups, one can make use of
 {p 8 8 2} {bf:. foreach g in {c 96}r(hdfgroup_names){c 39} {c -(}}    {break}
 {space 2}2. {it:do something for group {c 96}g{c 39}}    {break}
 {space 2}3. {bf:{c )-}}
+
+{p 4 4 2}
+If the coefficient names are stored in a dataset with some name other than {c 39}coefnames{c 39},
+it can be specified as follows:
+
+{p 8 8 2} {bf:. posthdf, cnames(key_for_names)}
+
+{p 4 4 2}
+To select a parser for interpreting the coefficient names:
+
+{p 8 8 2} {bf:. posthdf, parser(iwm)}
+
+{p 4 4 2}
+More details on the use of parsers can be found in {help posthdf##parsers:Parsers}.
+
+{p 4 4 2}
+{bf:Note:}
+
+{p 8 8 2} Whenever any option for keys or the parser is specified,
+as in the above two examples,
+they are applied to all the selected groups.
 
 {marker parsers}{...}
 


### PR DESCRIPTION
If the number of groups loaded into the memory passes the limit of Stata for `estimates store`, groups have to be posted in batches. In this scenario, being able to select the groups based on keywords in the group names is very useful.

The new options `with(strlist)` and `without(strlist)` are added for such a purpose. When `with()` is specified, only groups containing at least one of the strings passed to `with()` in the group name are posted. On the other hand, groups containing any of the strings passed to `without()` in the group name are excluded.